### PR TITLE
Update to v1.12.0 of sass-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
-.PHONY: image test
+.PHONY: clean image integration_test test
 
 IMAGE_NAME ?= codeclimate/codeclimate-sass-lint
 
+clean:
+	rm -rf tmp/
+
 image:
 	docker build --rm -t ${IMAGE_NAME} .
+
+integration_test:
+	test/integration/test.sh
 
 test:
 	docker run --rm ${IMAGE_NAME} sh -c "cd /usr/src/app && npm test"

--- a/engine.json
+++ b/engine.json
@@ -6,6 +6,6 @@
     "email": "michael@michaeljherold.com"
   },
   "languages": ["Sass"],
-  "version": "v1.11.1-1",
+  "version": "v1.12.0-1",
   "spec_version": "0.3.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -390,7 +390,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.31"
       }
     },
     "debug": {
@@ -452,9 +452,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.30",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
-      "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.31.tgz",
+      "integrity": "sha1-e7k4yVp/G59ygJLcCcQe3MOY7v4=",
       "requires": {
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
@@ -466,7 +466,7 @@
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
+        "es5-ext": "0.10.31",
         "es6-symbol": "3.1.1"
       }
     },
@@ -476,7 +476,7 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
+        "es5-ext": "0.10.31",
         "es6-iterator": "2.0.1",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -489,7 +489,7 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
+        "es5-ext": "0.10.31",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -501,7 +501,7 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.31"
       }
     },
     "es6-weak-map": {
@@ -510,7 +510,7 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
+        "es5-ext": "0.10.31",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
       }
@@ -634,7 +634,7 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.31"
       }
     },
     "exit-hook": {
@@ -828,13 +828,6 @@
         "glob": "7.1.2",
         "lodash": "4.17.4",
         "minimatch": "3.0.4"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
-        }
       }
     },
     "gonzales-pe": {
@@ -3398,9 +3391,9 @@
       "dev": true
     },
     "sass-lint": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/sass-lint/-/sass-lint-1.11.1.tgz",
-      "integrity": "sha512-vt29dGRlNDywZUsJOxhh8cGtpRWIqrsGS85U0WnAyMdywnUyiPXV3/HNKtkg7hmm6pRjpYE9806u/GT0oI+lMQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/sass-lint/-/sass-lint-1.12.0.tgz",
+      "integrity": "sha512-N0q34vSDwQSbtEqIy4Nx2XrX5vFTLi7Hvl4v2ec+yasjIdnvJNOxACz4/Mr7jZJdiFmNbMIftk6/Ih5GfpC1Gg==",
       "requires": {
         "commander": "2.11.0",
         "eslint": "2.13.1",
@@ -3453,9 +3446,9 @@
           }
         },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -3476,7 +3469,7 @@
           "requires": {
             "chalk": "1.1.3",
             "concat-stream": "1.6.0",
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "doctrine": "1.5.0",
             "es6-map": "0.1.5",
             "escope": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "commander": "^2.11.0",
     "deepmerge": "^1.5.2",
     "glob": "^7.1.2",
-    "sass-lint": "^1.11.1"
+    "sass-lint": "^1.12.0"
   },
   "devDependencies": {
     "app-module-path": "^2.2.0",

--- a/test/integration/test.sh
+++ b/test/integration/test.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+repos=(
+  Courseware/coursewa.re
+  DarthMax/Motrackt
+  DefactoSoftware/Hours
+  Gargron/mastodon
+  diaspora/diaspora
+  JoePym/UndergroundFootball
+  KPSU/kpsu.org
+  ManageIQ/manageiq-ui-classic
+  assemblymade/coderwall
+  coderwall/coderwall-next
+  comfy/comfortable-mexican-sofa
+  gitlabhq/gitlab-ci
+  rubycentral/cfp-app
+  sunlightlabs/opencongress
+  switchboard/switchboard
+  teambox/teambox
+  thoughtbot/hound
+  OakCH/scheduler
+  TAnarchy/rubrik
+  YouthTree/big-help-mob
+  adamklawonn/CityCircles
+  afternoonrobot/photographer-io
+  alg/family_hut
+  amirci/zenboard
+  andresmb/reclutamiento
+  andrewroth/project_application_tool
+  appelier/bigtuna
+  arailsdemo/arailsdemo2
+  asalant/freehub
+  EOL/eol
+)
+
+failure () {
+  local msg=$1
+
+  printf "\e[31m%s\e[39m\n" "$msg"
+}
+
+header () {
+  local msg=$1
+
+  printf "\n\e[33m%s\e[39m\n" "$msg"
+}
+
+message () {
+  local msg=$1
+
+  printf "%s\n" "$msg"
+}
+
+success () {
+  local msg=$1
+
+  printf "\e[32m%s\e[39m\n" "$msg"
+}
+
+test_repository () {
+  local repo=$1
+  local base
+  local dir
+
+  base=$(pwd)
+  dir=tmp/$(basename "$repo")
+
+  header "Testing $repo"
+
+  if [ ! -d "$dir" ]; then
+    echo -n "  Cloning repository ... "
+    (git clone "https://github.com/${repo}.git" "${dir}" >/dev/null 2>&1 && success "Finished!") || failure "Could not clone"
+  else
+    message "  Repository already exists"
+  fi
+
+  cd "${dir}" || return
+  write_config_file
+
+  echo -n "  Running engine ... "
+  (codeclimate analyze -e sass-lint --dev >/dev/null 2>&1 && success "Passed!") || failure "Failed!"
+
+  cd "${base}" || return
+}
+
+write_config_file () {
+  if [ ! -f .codeclimate.yml ] || ! grep -q sass-lint .codeclimate.yml; then
+    message "  Writing Code Climate configuration"
+    cat <<EOF > .codeclimate.yml
+engines:
+  sass-lint:
+    enabled: true
+EOF
+  else
+    message "  Code Climate configuration exists"
+  fi
+}
+
+trap 'failure "Interrupted!" && exit 1' SIGINT
+
+for repo in "${repos[@]}"; do
+  mkdir -p tmp/
+  test_repository "$repo"
+done


### PR DESCRIPTION
This includes a helper script to run through the list of repositories that I use as integration tests. The idea is that any time we update the engine, we should run the integration test before pushing the build.

I don't think it's a great idea to run this on Travis since it takes about 2.3GiB of disk space to download all of the repositories.