### PR TITLE
Fix engine.json location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:8.5-alpine
 LABEL maintainer "Michael J. Herold <michael@michaeljherold.com>"
 
 WORKDIR /usr/src/app
-COPY engine.json package*.json ./
+COPY engine.json /
+COPY package*.json ./
 
 RUN npm install --silent && \
   adduser -u 9000 -D app


### PR DESCRIPTION
According to [the Spec](https://github.com/codeclimate/spec/blob/master/SPEC.md#engine-specification-file), engine specification file must be in the root of FS.